### PR TITLE
test: remove extra treeshake test fixture

### DIFF
--- a/src/packages/recompose/__tests__/fixtures/treeshake-entry.js
+++ b/src/packages/recompose/__tests__/fixtures/treeshake-entry.js
@@ -1,1 +1,0 @@
-import '../../../../../lib/packages/recompose/es/Recompose.js'


### PR DESCRIPTION
not needed since the treeshake test was removed in
https://github.com/acdlite/recompose/pull/645