### PR TITLE
Update componentFromProp.js

### DIFF
--- a/src/packages/recompose/componentFromProp.js
+++ b/src/packages/recompose/componentFromProp.js
@@ -1,9 +1,8 @@
 import { createElement } from 'react'
-import omit from './utils/omit'
 
 const componentFromProp = propName => {
-  const Component = props =>
-    createElement(props[propName], omit(props, [propName]))
+  const Component = ({ [propName]: elementType, forwardedRef, ...props }) =>
+    createElement(elementType, { ...props, ref: forwardedRef })
   Component.displayName = `componentFromProp(${propName})`
   return Component
 }


### PR DESCRIPTION
Passes `forwardedRef` prop as the component `ref`. Removes the call to `omit()`.