### PR TITLE
refactor: update symbol-observable -> 4

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 46440,
-    "minified": 16396,
-    "gzipped": 4658
+    "bundled": 46563,
+    "minified": 16204,
+    "gzipped": 4622
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 42878,
-    "minified": 15116,
-    "gzipped": 4215
+    "bundled": 43001,
+    "minified": 14924,
+    "gzipped": 4181
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
     "bundled": 32328,

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -17,7 +17,7 @@
     "change-emitter": "^0.1.2",
     "hoist-non-react-statics": "^2.3.1",
     "react-lifecycles-compat": "^3.0.2",
-    "symbol-observable": "^1.0.4"
+    "symbol-observable": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"

--- a/src/packages/recompose/yarn.lock
+++ b/src/packages/recompose/yarn.lock
@@ -29,7 +29,7 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-symbol-observable@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
-  integrity sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==


### PR DESCRIPTION
in src/packages/recompose

and update .size-snapshot.json

this was part of the major updates proposed in PR #16

✅ impact of size increase is under 10% in one case, with size decrease in some other cases

Unfortunately I do not see the git history for symbol-observable@4.0.0 release, raised this: https://github.com/benlesh/symbol-observable/issues/60

I would like to keep this update on hold until I found the git history for symbol-observable 4.