### PR TITLE
ALT RFC: remove @babel/transform-runtime from build, etc. - BREAKING DRAFT WIP

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "lib/packages/recompose/dist/Recompose.umd.js": {
-    "bundled": 45963,
-    "minified": 16127,
-    "gzipped": 4614
+    "bundled": 34552,
+    "minified": 12266,
+    "gzipped": 4019
   },
   "lib/packages/recompose/dist/Recompose.min.js": {
-    "bundled": 42401,
-    "minified": 14847,
-    "gzipped": 4171
+    "bundled": 31284,
+    "minified": 11044,
+    "gzipped": 3607
   },
   "lib/packages/recompose/dist/Recompose.esm.js": {
-    "bundled": 32325,
-    "minified": 15138,
-    "gzipped": 3567,
+    "bundled": 22295,
+    "minified": 11201,
+    "gzipped": 2988,
     "treeshaked": {
       "rollup": {
-        "code": 310,
-        "import_statements": 310
+        "code": 127,
+        "import_statements": 127
       },
       "webpack": {
-        "code": 444
+        "code": 272
       }
     }
   }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,15 @@
 module.exports = {
   plugins: [['@babel/proposal-class-properties', { loose: true }]],
-  presets: [['@babel/env', { loose: true }], '@babel/react'],
+  presets: [
+    [
+      '@babel/env',
+      {
+        loose: true,
+        targets: { node: 16 },
+      },
+    ],
+    '@babel/react',
+  ],
 }
 
 // if (process.env.NODE_ENV === 'cjs') {

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,4 +18,4 @@ module.exports = {
 
 // As of Jest 27, this seems to be needed regardless of process.env.NODE_ENV
 // TODO: look for documentation *why* this is needed
-module.exports.plugins.push('@babel/transform-runtime')
+// module.exports.plugins.push('@babel/transform-runtime')

--- a/src/packages/recompose/__tests__/withHandlers-test.js
+++ b/src/packages/recompose/__tests__/withHandlers-test.js
@@ -70,7 +70,7 @@ test('withHandlers warns if handler is not a higher-order function', () => {
   const wrapper = mount(<Button />)
   const button = wrapper.find('button')
 
-  expect(() => button.simulate('click')).toThrowError(/undefined/)
+  expect(() => button.simulate('click')).toThrowError(/handler is not a function/)
 
   expect(error.firstCall.args[0]).toBe(
     'withHandlers(): Expected a map of higher-order functions. Refer to ' +

--- a/src/packages/recompose/__tests__/withHandlers-test.js
+++ b/src/packages/recompose/__tests__/withHandlers-test.js
@@ -70,7 +70,9 @@ test('withHandlers warns if handler is not a higher-order function', () => {
   const wrapper = mount(<Button />)
   const button = wrapper.find('button')
 
-  expect(() => button.simulate('click')).toThrowError(/handler is not a function/)
+  expect(() => button.simulate('click')).toThrowError(
+    /handler is not a function/
+  )
 
   expect(error.firstCall.args[0]).toBe(
     'withHandlers(): Expected a map of higher-order functions. Refer to ' +


### PR DESCRIPTION
This is basically the reverse of something I tried in: https://github.com/brodybits/rollup-plugin-size-snapshot/pull/11

*could* simplify the build & reduce build size ... would likely break use with at least some browsers

STATUS: not likely to be accepted or merged

TODO:

- [ ] remove from dev dependencies
- [ ] possibly update to include CJS size, as proposed in PR #20
- [ ] cleanup & reorganize the commits (if this would ever be merged)