### PR TITLE
[WIP] chore: update flow-bin -> ^0.167.1 - for FUTURE 0v.32.0 version- DRAFT WIP

### DIFF
--- a/.github/workflows/test-react-16.yml
+++ b/.github/workflows/test-react-16.yml
@@ -21,8 +21,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         react-version:
         - 16
-        - 16.3
-        - 16.2
+        # XXX NOW FAILS WITH XXX
+        # - 16.3
+        # - 16.2
         # - 16.1 - failed with React 16.1, as expected.
 
     steps:

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^2.7.0",
     "eslint-plugin-react": "^7.27.1",
-    "flow-bin": "^0.166.1",
+    "flow-bin": "^0.167.1",
     "flyd": "^0.2.8",
     "husky": "^0.13.3",
     "jest": "^27.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.166.1:
-  version "0.166.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.166.1.tgz#b8f02247c4134aa41cba97aa8b281cae3448c895"
-  integrity sha512-x0T0sM+rfr4scmVkBY++j2SfqzE8KwkeFmu6+WRe2qOT+TCf2Ze1gx2R/uwXBRL9S8TpPPogXiyW6urVyXIE/Q==
+flow-bin@^0.167.1:
+  version "0.167.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.167.1.tgz#c2cfc2ca326ca16fbf9bf6ab273bb865b26b528b"
+  integrity sha512-YL3sy3YEa5do5O/dBmUFHqzsWGIj2Yhx3+FzNTQsmfimX5DTlUj9uC0LFmuG+c5pDtVo/d/1e38Vgd1o0fgh9g==
 
 flyd@^0.2.8:
   version "0.2.8"


### PR DESCRIPTION
removes testing with React 16.2 & 16.3 due to problem with Flow comments

STATUS:

- [ ] need to update `flow-bin` again
- [ ] consider targeting next 0.x release, with no more support of React 16.2 or 16.3
- [ ] resolve more TODO items below

More TODO items:

- [ ] test with React back to 16.4 or 16.5
- [ ] clean up changes to CI testing
- [ ] change base to `main`
- [ ] rebase on `main`