### PR TITLE
[DRAFT TBD] chore: restore conditional Babel plugin config - DRAFT WIP

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,10 +3,7 @@ module.exports = {
   presets: [['@babel/env', { loose: true }], '@babel/react'],
 }
 
-// if (process.env.NODE_ENV === 'cjs') {
-//   module.exports.plugins.push(... ...)
-// }
-
-// As of Jest 27, this seems to be needed regardless of process.env.NODE_ENV
-// TODO: look for documentation *why* this is needed
-module.exports.plugins.push('@babel/transform-runtime')
+// TODO: find link to explain *why* @babel/transform-runtime is needed here
+if (process.env.NODE_ENV === 'cjs' || process.env.NODE_ENV === 'test') {
+  module.exports.plugins.push('@babel/transform-runtime')
+}


### PR DESCRIPTION
conditional Babel configuration with condition as in commit ea0a6e56ca177ccf3a4be2cf88ab38737ffde0a5

(before commit ff1c72c574661ae5eccc1839448db12585082442 - Babel 7 update)

**does** seem to work with Jest 27 in this project

and new TODO comment:

```js
// TODO: find link to explain *why* @babel/transform-runtime is needed here
```

__status:__ I will likely just revert the changes for Jest 27 update before making the patch release, and keep this update for a future minor (0.x) release