### PR TITLE
Remove function branch from `Handlers` generic default in `withHandlers` type declaration

### DIFF
--- a/src/packages/recompose/__tests__/types/test_withHandlers.js
+++ b/src/packages/recompose/__tests__/types/test_withHandlers.js
@@ -13,7 +13,6 @@ type EnhancedCompProps = {
 }
 
 const enhancer: HOC<*, EnhancedCompProps> = compose(
-  // $FlowFixMe[incompatible-use]
   withHandlers({
     onValueChange: props => value => {
       props.onChange(value)
@@ -39,7 +38,6 @@ const enhancer: HOC<*, EnhancedCompProps> = compose(
 
 // check that factory init works as expected
 const enhancer2: HOC<*, EnhancedCompProps> = compose(
-  // $FlowFixMe[incompatible-use]
   withHandlers(() => ({
     onValueChange: props => value => {
       props.onChange(value)

--- a/src/packages/recompose/index.js.flow
+++ b/src/packages/recompose/index.js.flow
@@ -112,15 +112,7 @@ declare export function withStateHandlers<
 
 declare export function withHandlers<
   Enhanced,
-  Handlers:
-    | ((
-        props: Enhanced
-      ) => {
-        [key: string]: (props: Enhanced) => Function,
-      })
-    | {
-        [key: string]: (props: Enhanced) => Function,
-      }
+  Handlers: {[key: string]: (props: Enhanced) => Function}
 >(
   handlers: ((props: Enhanced) => Handlers) | Handlers
 ): HOC<


### PR DESCRIPTION
Fixes an issue where invoking `withHandlers` always results in a Flow error:

```js
// Flow error that would be emitted by invoking withHandlers:
// Cannot call withHandlers because function type [1] is not a valid argument of $ObjMap [2]. [incompatible-use]
withHandlers({
  onClick: props => () => props.doSomething(),
})
```

The Flow error is caused by the function branch in the default value for the `Handlers` generic defined in the `withHandlers` Flow type declaration. `Handlers` is later used as the first argument to `$ObjMap` which is correctly identified as problematic from Flow v.0.117.0 onwards ([thanks to improvements to the behaviors of type destructors when applied to unions](https://github.com/facebook/flow/blob/main/Changelog.md#01170)).

Definition of `Handlers` default:
https://github.com/react-recompose/react-recompose/blob/cdef76cbd1ccfa8ff785eeed07ae8092b4ad006d/src/packages/recompose/index.js.flow#L115-L123

Usage of `Handlers` in `$ObjMap`:
https://github.com/react-recompose/react-recompose/blob/cdef76cbd1ccfa8ff785eeed07ae8092b4ad006d/src/packages/recompose/index.js.flow#L127-L130

The fix is to simply remove the function branch from the `Handlers` default. My interpretation is that the union type with the function branch has been left there from some past type refactor (prior to v0.117.0) and was overlooked because Flow did not complain about it. This is supported by the fact that the call signature also defines the only `withHandlers` argument as a union with a function branch:

https://github.com/react-recompose/react-recompose/blob/cdef76cbd1ccfa8ff785eeed07ae8092b4ad006d/src/packages/recompose/index.js.flow#L124-L126

