### PR TITLE
feat: update hoist-non-react-statics -> 3 (...)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "Recompose.umd.js": {
-    "bundled": 45256,
-    "minified": 16212,
-    "gzipped": 4650
+    "bundled": 53668,
+    "minified": 18967,
+    "gzipped": 5551
   },
   "Recompose.min.js": {
-    "bundled": 42220,
-    "minified": 14952,
-    "gzipped": 4214
+    "bundled": 46068,
+    "minified": 17473,
+    "gzipped": 4970
   },
   "Recompose.esm.js": {
     "bundled": 32130,

--- a/src/packages/recompose/package.json
+++ b/src/packages/recompose/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "change-emitter": "^0.1.6",
-    "hoist-non-react-statics": "^2.5.5",
+    "hoist-non-react-statics": "^3.3.2",
     "react-lifecycles-compat": "^3.0.4",
     "symbol-observable": "^1.2.0"
   },

--- a/src/packages/recompose/yarn.lock
+++ b/src/packages/recompose/yarn.lock
@@ -14,10 +14,17 @@ change-emitter@^0.1.6:
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
   integrity sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw==
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
with updated .size-snapshot.json

seems to have significant increase in bundle size

targeting a future release such as v0.33.0