### PR TITLE
lint: do not disable import/no-unresolved

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,6 @@
     "no-return-assign": [0],
     "max-len": ["error", { "code": 120, "ignorePattern": "^test", "ignoreUrls": true }],
     "lines-between-class-members": [0],
-    "import/no-unresolved": [0],
     "import/no-extraneous-dependencies": [0],
     "import/extensions": [0],
     "import/prefer-default-export": [0],


### PR DESCRIPTION
could have detected missing `lodash` before I pushed this react-recompose version commit: e64dae723e4c1e2874740c9210da9b0a96947037

```
/Users/brodybits/react-recompose/scripts/release.js
  7:40  error  Unable to resolve path to module 'lodash'  import/no-unresolved
```

TODO:

- [ ] sort out errors in `src/packages/recompose-relay/createContainer.js`

```
/Users/brodybits/react-recompose/src/packages/recompose-relay/createContainer.js
  1:19  error  Unable to resolve path to module 'react-relay'  import/no-unresolved
  2:25  error  Unable to resolve path to module 'recompose'    import/no-unresolved
```

may need to add another .eslintrc file in `src/packages/recompose-relay`